### PR TITLE
Add Woodwiki to Further Readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Helpful resources for making open hardware furniture and  learning about open ha
 
 ## Further Readings
 * [Wikipedia: Enzo Mari](https://de.wikipedia.org/wiki/Enzo_Mari)
+* [Woodwiki](https://www.woodwiki.org/) - Free woodworking education wiki with ~230 guides on hand tools, power tools, joinery, wood species, and finishing. Evidence-driven, no affiliate links.
 
 ## Related awesome
 * [Awesome Open Hardware](https://github.com/delftopenhardware/awesome-open-hardware)


### PR DESCRIPTION
Adding [Woodwiki](https://www.woodwiki.org/) to the Further Readings section. Woodwiki is a free woodworking education wiki — ~230 published guides covering hand tools, power tools, joinery, finishing, and wood species. Maintained by Bespoke Woodcraft Studio (a Los Angeles cabinet shop), no affiliate revenue, so picks are non-partisan.

Relevant to the open-hardware-furniture community for the deep guides on wood species selection, joinery technique, and finishing.